### PR TITLE
Introduce 'newModule' (boolean) to make html2js could work easily on existing AngularJS module

### DIFF
--- a/tasks/html2js.js
+++ b/tasks/html2js.js
@@ -131,6 +131,7 @@ module.exports = function(grunt) {
     var options = this.options({
       base: 'src',
       module: 'templates-' + this.target,
+      newModule: true,
       quoteChar: '"',
       fileHeaderString: '',
       fileFooterString: '',
@@ -186,10 +187,10 @@ module.exports = function(grunt) {
 
       if (options.singleModule) {
         if (options.target == 'js') {
-          bundle = "angular.module('" + targetModule + "', []).run(['$templateCache', function($templateCache) {\n";
+          bundle = "angular.module('" + targetModule + (options.newModule? "', []" : "'") + ").run(['$templateCache', function($templateCache) {\n";
           modules += '\n}]);\n';
         } else if (options.target == 'coffee') {
-          bundle = "angular.module('" + targetModule + "', []).run(['$templateCache', ($templateCache) ->\n";
+          bundle = "angular.module('" + targetModule + (options.newModule? "', []" : "'") + ").run(['$templateCache', ($templateCache) ->\n";
           modules += '\n])\n';
         }
       } else if (targetModule) {


### PR DESCRIPTION
AngularJS allows to call directly `run(['$templateCache', function($templateCache) {..}])` method on an existing AngularJS module by setting 'require' argument of `angular.module(name, require, ...)` to null instead of an array object. But it is hard-coded by an empty array in current html2js code (singleMode=true).

Here is my scenario:

I have an AngularJS module 'app'. By using grunt-contrib-concat, I want to merge all parts (controllers, services, directives, filters...) from different files to a single file. The output is:

```
// Source: app/app.js
angular.module("app").config([function() {
...
}]);
// Source: app/directive/abc.js
angular.module('app').directive('abc', function() {
...
});
// Source: app/filters/abc.js
angular.module('app').filter('abc', function() {
...
});
```

I also want to add the js file contents generated by html2js for my templates to that single file but I couldn't if doing with current html2js code.

```
// Source: app/filters/abc.js
angular.module('app', []).filter('abc', function() { // new module with name 'app' is created because 'require' param is an array
...
});
```

 So I expected the 'newModule' option can solve my problem.

Please review it.
