### PR TITLE
Don't generate empty modules

### DIFF
--- a/tasks/html2js.js
+++ b/tasks/html2js.js
@@ -168,6 +168,9 @@ module.exports = function(grunt) {
         }
 
       });
+      
+      // don't generate empty modules
+      if (!modules.length) return;
 
       counter += modules.length;
       modules  = modules.join('\n');

--- a/tasks/html2js.js
+++ b/tasks/html2js.js
@@ -170,7 +170,7 @@ module.exports = function(grunt) {
       });
       
       // don't generate empty modules
-      if (!modules.length) return;
+      if (!modules.length) { return; }
 
       counter += modules.length;
       modules  = modules.join('\n');


### PR DESCRIPTION
Empty modules can be generated if the configured source doesn't capture any files (e.g. 'empty_folder/*.js').
