### PR TITLE
Update html-minifier dependency from ~0.6.0 to ~3.0.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,6 +48,16 @@ module.exports = function(grunt) {
         dest: 'tmp/empty_attribute.js'
       },
 
+      custom_attribute_collapse: {
+        src: ['test/fixtures/custom_attribute_collapse.tpl.html'],
+        dest: 'tmp/custom_attribute_collapse.js',
+        options: {
+          htmlmin: {
+            customAttrCollapse: /my-[a-z]*/
+          }
+        }
+      },
+
       files_object_default_options: {
         files: {
           'tmp/files_object_default_options_1.js': ['test/fixtures/one.tpl.html'],

--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ options: {
 }
 ```
 
+In addition, the `customAttrCollapse` option is supported, allowing you to supply a regex that
+is used to match attribute names in which multiple whitespace will be collapsed to a single space.
+
 #### process:
 Type: `Object` or `Boolean` or `Function`
 Default value: `false`

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
   ],
   "dependencies": {
     "chokidar": "^1.0.0",
-    "html-minifier": "~0.6.0"
+    "html-minifier": "~3.0.0"
   }
 }

--- a/tasks/html2js.js
+++ b/tasks/html2js.js
@@ -193,7 +193,7 @@ module.exports = function(grunt) {
         } else if (options.target === 'coffee') {
           compiled = compileCoffeeTemplate(moduleName, filepath, options);
         } else {
-          grunt.fail.fatal('Unknow target "' + options.target + '" specified');
+          grunt.fail.fatal('Unknown target "' + options.target + '" specified');
         }
 
         if (options.watch) {

--- a/test/expected/custom_attribute_collapse.js
+++ b/test/expected/custom_attribute_collapse.js
@@ -1,0 +1,7 @@
+angular.module('templates-custom_attribute_collapse', ['../test/fixtures/custom_attribute_collapse.tpl.html']);
+
+angular.module("../test/fixtures/custom_attribute_collapse.tpl.html", []).run(["$templateCache", function($templateCache) {
+  $templateCache.put("../test/fixtures/custom_attribute_collapse.tpl.html",
+    "<div my-style=\"background-color: red;font-size: large;\"></div>\n" +
+    "");
+}]);

--- a/test/fixtures/custom_attribute_collapse.tpl.html
+++ b/test/fixtures/custom_attribute_collapse.tpl.html
@@ -1,0 +1,5 @@
+<div
+        my-style="
+            background-color: red;
+            font-size: large;"
+></div>

--- a/test/html2js_test.js
+++ b/test/html2js_test.js
@@ -74,6 +74,16 @@ exports.html2js = {
 
         test.done();
     },
+    custom_attribute_collapse: function (test) {
+
+        test.expect(1);
+
+        assertFileContentsEqual(test, 'tmp/custom_attribute_collapse.js',
+            'test/expected/custom_attribute_collapse.js',
+            'expected compiled template module');
+
+        test.done();
+    },
     compact_format_default_options: function (test) {
 
         test.expect(1);


### PR DESCRIPTION
This upgrade will allow the collapse of white space in specific attributes
supplied as a regex in the htmlmin options.

For example:

```
  options: {
    htmlmin: {
      customAttrCollapse: /my-[a-z]*/
    }
  }
```

will compress whitespace in all attributes whose name starts with "my-".